### PR TITLE
[ENGX-334] Fix the incorrect import on the type file.

### DIFF
--- a/typings/notification.d.ts
+++ b/typings/notification.d.ts
@@ -1,14 +1,14 @@
-import { Block, KnownBlock, MessageAttachment } from '@slack/webhook'
+import { Block, KnownBlock, MessageAttachment } from '@slack/types'
 
 export namespace Notification {
   interface AlertsProps {
-    name?: string; 
-    title?: string; 
-    message?: string; 
+    name?: string;
+    title?: string;
+    message?: string;
     footer?: string;
     color: string;
   }
-  
+
   interface Alerts {
     info: (args: Omit<AlertsProps, 'color'>, appName?: string) => Promise<void>;
     error: (args: Omit<AlertsProps, 'color'>, appName?: string) => Promise<void>;


### PR DESCRIPTION
Hi @reb2020 ,

The import of the notification.d.ts is not correct, which makes the build in the svc-public-offer fail when I added the lib-notification there.

The PR just update the import with the right path.

Cheers.